### PR TITLE
Feature/eu868 join fix

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -40,17 +40,17 @@ extern "C"
 #include "port.h"
 
 // Constants
-#define UART_READ_TIMEOUT_MS 100
+#define UART_READ_TIMEOUT_MS 2000
 #define UART_WRITE_TIMEOUT_MS 10
 
-#define API_FRAME_DEBUG_PRINT_ENABLED 1
+#define API_FRAME_DEBUG_PRINT_ENABLED 0
 #if API_FRAME_DEBUG_PRINT_ENABLED
 #define APIFrameDebugPrint(...) portDebugPrintf(__VA_ARGS__)
 #else
 #define APIFrameDebugPrint(...)
 #endif
 
-#define XBEE_DEBUG_PRINT_ENABLED 1
+#define XBEE_DEBUG_PRINT_ENABLED 0
 #if XBEE_DEBUG_PRINT_ENABLED
 #define XBEEDebugPrint(...) portDebugPrintf(__VA_ARGS__)
 #else

--- a/src/xbee_lr.c
+++ b/src/xbee_lr.c
@@ -133,20 +133,23 @@ void XBeeLRProcess(XBee* self) {
  */
 bool XBeeLRConnect(XBee* self) {
     // Implement XBeeLR specific connection logic 
+    XBEEDebugPrint("Join Request Sent...\n");
     SendJoinReqApiFrame(self);
 
     // Start the timeout timer
     uint32_t startTime = portMillis();
 
-    while ((portMillis() - startTime) < CONNECTION_TIMEOUT_MS) {
-        if (XBeeLRConnected(self)) {
-            XBEEDebugPrint("Successfully Joined\n");
-            return true; // Successfully joined
-        }
+    //Delay until CONNECTION_TIMEOUT_MS Time has elapsed
+    while((portMillis() - startTime) < CONNECTION_TIMEOUT_MS){}
 
-        portDelay(500); // Delay between checks 
+    XBEEDebugPrint("Checking Join Status...\n");
+    //Check Join Status only once per Join Request
+    if (XBeeLRConnected(self)) {
+        XBEEDebugPrint("Successfully Joined\n");
+        return true; // Successfully joined
     }
 
+    portDelay(500); // Delay between checks 
     XBEEDebugPrint("Failed to Join\n");
     return false; // Timeout reached without successful join
 }

--- a/src/xbee_lr.h
+++ b/src/xbee_lr.h
@@ -45,7 +45,8 @@ extern "C"
 #include "xbee.h"
 #include "config.h"
 
-#define CONNECTION_TIMEOUT_MS 6000
+//Minimum Connection Timeout required for EU868 Join is 8000ms
+#define CONNECTION_TIMEOUT_MS 8000 
 #define SEND_DATA_TIMEOUT_MS 10000
 
 // Structure for XBee LR LoRaWAN packet


### PR DESCRIPTION
- Increased Connection Timeout to 8seconds to support EU868 Region Join.
- Turned Off Debug Print.
- Increased UART Read Timeout to 2000ms.
- Changed Implementation of Join Status. Join Status is only checked once per Join Request, after the CONNECTION_TIMEOUT_MS Time has elapsed.
